### PR TITLE
Update ICommandBinding.cls

### DIFF
--- a/MVVM/ICommandBinding.cls
+++ b/MVVM/ICommandBinding.cls
@@ -25,6 +25,6 @@ Attribute Command.VB_Description = "Gets the command bound to the event source."
 End Property
 
 '@Description "Evaluates whether the command can execute given the binding context."
-Public Sub EvaluateCanExecute(ByVal Context As Object)
+Public Sub EvaluateCanExecute
 Attribute EvaluateCanExecute.VB_Description = "Evaluates whether the command can execute given the binding context."
 End Sub


### PR DESCRIPTION
See other proposed change as well.

Breaking? change to interface, but removes confusion caused by a CommandBinding potentially evaluating CanExecute in an arbitrary context (Context as object) but always executing the Command with respect to an internally stored ViewModel